### PR TITLE
Add prettier for automatic code formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["prettier"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Run Prettier
+        run: npm run format
+
   typecheck:
     name: TypeScript
     runs-on: ubuntu-latest

--- a/components.json
+++ b/components.json
@@ -8,7 +8,8 @@
     "css": "app/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
-    "prefix": ""
+    "prefix": "",
+    "prettier": true
   },
   "aliases": {
     "components": "@/components",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "clean": "rimraf .next out node_modules",
-    "deploy": "vercel"
+    "deploy": "vercel",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",
@@ -80,7 +81,8 @@
     "eslint-config-next": "15.2.1",
     "jest": "^29.7.0",
     "rimraf": "^5.0.5",
-    "supabase": "^2.15.8"
+    "supabase": "^2.15.8",
+    "prettier": "^2.8.8"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,5 +8,6 @@ module.exports = {
   },
   plugins: [
     require('tailwindcss-animate'),
+    require('prettier'),
   ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "plugins": [
       {
         "name": "next"
+      },
+      {
+        "name": "prettier"
       }
     ],
     "paths": {


### PR DESCRIPTION
Related to #11

Add automatic linting and formatting to the project.

* **package.json**: Add `"format": "prettier --write ."` to the `scripts` section and add `prettier` to the `devDependencies` section.
* **components.json**: Add `prettier` to the `tailwind` section.
* **tsconfig.json**: Add `prettier` to the `plugins` section.
* **tailwind.config.js**: Add `prettier` to the `plugins` section.
* **.eslintrc.json**: Add `prettier` to the `extends` and `plugins` sections.
* **.github/workflows/ci.yml**: Add a step to run `npm run format` after the `Run ESLint` step in the `lint` job.

